### PR TITLE
Fix to call `close` even if `readyState` is not open

### DIFF
--- a/lib/transports/websocket.js
+++ b/lib/transports/websocket.js
@@ -132,7 +132,7 @@ WSConnection.prototype.disconnect = function () {
     } else {
         this.hasStream = false;
         this.stream = undefined;
-        if (this.conn.readyState === WS_OPEN) {
+        if (this.conn) {
             this.conn.close();
         }
         this.conn = undefined;


### PR DESCRIPTION
Thank you very much for developing.

I'm faced with memory leak.
If `readyState` is not open, the connection isn't released and it might cause memory leak.
Could you check this PR?